### PR TITLE
Fixed link to Zen of GitHub

### DIFF
--- a/content/guides/introduction.mdx
+++ b/content/guides/introduction.mdx
@@ -41,4 +41,4 @@ Primer patterns and components aim towards accessible solutions that don’t dil
 
 ---
 
-Next: [The Zen of GitHub](/foundations/zen)
+Next: [The Zen of GitHub](/guides/zen)


### PR DESCRIPTION
The link at the bottom of the design intro page to Zen of GitHub was old and 404-ing. This PR fixes is.